### PR TITLE
Add OTP functionality to SignInModal and update API endpoints

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -26,6 +26,7 @@ export const API_ENDPOINTS = {
   AUTHENTICATE: `${API_BASE_URL}/authenticate`,
   LOGIN: `${API_BASE_URL}/login`,
   REGISTER: `${API_BASE_URL}/register`,
+  REGISTER_CONFIRM: `${API_BASE_URL}/register_confirm`,
   DESIGNATIONS: `${API_BASE_URL}/designations`,
   USER_ROLES: `${API_BASE_URL}/user-roles`,
   GET_EMAIL: `${API_BASE_URL}/get-email`,

--- a/src/components/auth/SignInModal.tsx
+++ b/src/components/auth/SignInModal.tsx
@@ -24,19 +24,49 @@ export function SignInModal({ open, onOpenChange, onSwitch }: SignInModalProps) 
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
-  const { signIn, forgotPassword } = useAuth();
+
+  const [isOtp, setIsOtp] = useState(false);
+  const [otp, setOtp] = useState("");
+  const [otpSubmitting, setOTPSubmitting] = useState(false);
+  const [otpSent, setOtpSent] = useState(false);
+  const [resendOtpTimer, setResendOtpTimer] = useState(0);
+  const [resendOtpTimerInterval, setResendOtpTimerInterval] = useState<NodeJS.Timeout | null>(null);
+
+  const [isResendOtpDisabled, setIsResendOtpDisabled] = useState(false);
+
+  const handleResendOtpCountdown = () => {
+    let timer = 60;
+    const interval = setInterval(() => {
+      timer--;
+      setResendOtpTimer(timer);
+      setIsResendOtpDisabled(true);
+      if (timer === 0) {
+        clearInterval(interval);
+        setResendOtpTimerInterval(null);
+        setIsResendOtpDisabled(false);
+      }
+    }, 1000);
+    setResendOtpTimerInterval(interval);
+  };
+
+  const { signIn, signInWithOtp, verifyOtp, forgotPassword } = useAuth();
+
   const navigate = useNavigate();
 
   const { search } = useLocation();
   const searchParams = new URLSearchParams(search);
   const orgId = searchParams.get("org_id");
 
-  const handleEmailPasswordSignIn = async (e: React.FormEvent) => {
+  const handleSignIn = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
 
     try {
-      await signIn(identifier, password);
+      if (isOtp) {
+        await verifyOtp(identifier, otp);
+      } else {
+        await signIn(identifier, password);
+      }
 
       toast({
         title: "Welcome back!",
@@ -76,6 +106,22 @@ export function SignInModal({ open, onOpenChange, onSwitch }: SignInModalProps) 
     }
   };
 
+  const handleOtpSend = async (e) => {
+    e.preventDefault();
+    setOTPSubmitting(true);
+    try {
+      await signInWithOtp(identifier);
+      toast({ title: "Check your inbox", description: "OTP sent successfully." });
+      setIsOtp(true);
+      setOtpSent(true);
+    } catch (err: any) {
+      toast({ title: "Failed to send OTP", description: err.message, variant: "destructive" });
+    } finally {
+      setOTPSubmitting(false);
+      handleResendOtpCountdown();
+    }
+  };
+
   return (
     <Dialog
       open={open}
@@ -92,7 +138,7 @@ export function SignInModal({ open, onOpenChange, onSwitch }: SignInModalProps) 
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleEmailPasswordSignIn} className="space-y-4">
+        <form onSubmit={handleSignIn} className="space-y-4">
           <div>
             <Label htmlFor="signin-identifier">Email or Username</Label>
             <Input
@@ -104,21 +150,72 @@ export function SignInModal({ open, onOpenChange, onSwitch }: SignInModalProps) 
               required
             />
           </div>
-          <div>
-            <Label htmlFor="signin-password">Password</Label>
-            <Input
-              id="signin-password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="Enter your password"
-              required
-            />
-          </div>
-          <div className="text-right">
+
+          {!isOtp && (
+            <div>
+              <div className="flex justify-between h-5">
+                <Label htmlFor="signin-password">Password</Label>
+              </div>
+              <div>
+                <Input
+                  id="signin-password"
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="Enter your password"
+                  required
+                />
+              </div>
+            </div>
+
+          )}
+          {isOtp && (
+            <div>
+              <div className="flex justify-between h-5">
+                <Label htmlFor="signin-otp">OTP</Label>
+                <button
+                  type="button"
+                  className="text-sm text-green-600 cursor-pointer  disabled:opacity-50"
+                  onClick={handleOtpSend}
+                  disabled={otpSubmitting || isResendOtpDisabled || loading}
+                >
+
+
+                  {(otpSent ? (otpSubmitting ? "Sending OTP..." : (resendOtpTimer > 0 ? "Re-send OTP (" + resendOtpTimer + "s)" : "Re-send OTP")) : (otpSubmitting ? "Sending OTP..." : "Send OTP"))}
+
+                  {/* {(otpSubmitting ? "Sending OTP..." : (isOtp ? (resendOtpTimer > 0 ? "Re-send OTP (" + resendOtpTimer + "s)" : "Re-send OTP") : "Send OTP"))} */}
+                </button>
+              </div>
+              <div >
+
+                <Input
+                  id="signin-otp"
+                  type="text"
+                  value={otp}
+                  onChange={(e) => setOtp(e.target.value)}
+                  placeholder="Enter your OTP"
+                  required
+                />
+              </div>
+            </div>
+          )}
+
+          <div className="flex justify-between">
             <button
               type="button"
-              className="text-sm text-green-600 hover:underline"
+              className="text-sm text-green-600 cursor-pointer  disabled:opacity-50"
+              onClick={() => setIsOtp(!isOtp)}
+              disabled={loading}
+            >
+              {/* {(otpSubmitting ? "Sending OTP..." : (isOtp ? (resendOtpTimer > 0 ? "Re-send OTP (" + resendOtpTimer + "s)" : "Re-send OTP") : "Login with OTP"))} 
+              
+              */}
+
+              {isOtp ? "Sign in with Password" : "Sign in with OTP"}
+            </button>
+            <button
+              type="button"
+              className="text-sm text-green-600 cursor-pointer  disabled:opacity-50"
               onClick={handleSend}
               disabled={submitting}
             >
@@ -127,7 +224,7 @@ export function SignInModal({ open, onOpenChange, onSwitch }: SignInModalProps) 
           </div>
           <Button
             type="submit"
-            className="w-full bg-tasksmate-gradient"
+            className="w-full bg-tasksmate-gradient cursor-pointer disabled:opacity-50"
             disabled={loading}
           >
             {loading ? "Signing in..." : "Sign In"}
@@ -136,7 +233,7 @@ export function SignInModal({ open, onOpenChange, onSwitch }: SignInModalProps) 
             Don't have an account?{" "}
             <button
               type="button"
-              className="text-green-600 hover:underline font-medium"
+              className="text-green-600 cursor-pointer  font-medium"
               onClick={() => {
                 onOpenChange(false);
                 onSwitch?.();


### PR DESCRIPTION
- Introduced OTP-based sign-in option in SignInModal, allowing users to log in using an OTP sent to their email.
- Added state management for OTP handling, including countdown for resending OTP.
- Updated API endpoints in config.ts to include REGISTER_CONFIRM.
- Modified useAuth hook to support sign-in with OTP and OTP verification methods.